### PR TITLE
Only prevent default shortcut if handled

### DIFF
--- a/src/DockMonitor.js
+++ b/src/DockMonitor.js
@@ -48,15 +48,16 @@ export default class DockMonitor extends Component {
     if (!e.ctrlKey) {
       return;
     }
-    e.preventDefault();
 
     const key = e.keyCode || e.which;
     const char = String.fromCharCode(key);
     switch (char.toUpperCase()) {
     case this.props.toggleVisibilityKey.toUpperCase():
+      e.preventDefault();
       this.props.dispatch(toggleVisibility());
       break;
     case this.props.changePositionKey.toUpperCase():
+      e.preventDefault();
       this.props.dispatch(changePosition());
       break;
     default:


### PR DESCRIPTION
As reported in https://github.com/gaearon/redux-devtools/pull/132#issuecomment-149000244

This allows me to still do e.g. `ctrl+r` to refresh
