### PR TITLE
use the parse-key package to allow more complex keybindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "babel-runtime": "^5.8.25",
+    "parse-key": "^0.2.1",
     "react-dock": "^0.2.1",
     "react-pure-render": "^1.0.2"
   }

--- a/src/DockMonitor.js
+++ b/src/DockMonitor.js
@@ -3,6 +3,7 @@ import Dock from 'react-dock';
 import { POSITIONS } from './constants';
 import { toggleVisibility, changePosition, changeSize } from './actions';
 import reducer from './reducers';
+import parseKey from 'parse-key';
 
 export default class DockMonitor extends Component {
   static reducer = reducer;
@@ -44,24 +45,26 @@ export default class DockMonitor extends Component {
     window.removeEventListener('keydown', this.handleKeyDown);
   }
 
-  handleKeyDown(e) {
-    if (!e.ctrlKey) {
-      return;
-    }
+  matchesKey(key, event) {
+    const charCode = event.keyCode || event.which;
+    const char = String.fromCharCode(charCode);
+    return key.name.toUpperCase() === char.toUpperCase() &&
+      key.alt === event.altKey &&
+      key.ctrl === event.ctrlKey &&
+      key.meta === event.metaKey &&
+      key.shift === event.shiftKey;
+  }
 
-    const key = e.keyCode || e.which;
-    const char = String.fromCharCode(key);
-    switch (char.toUpperCase()) {
-    case this.props.toggleVisibilityKey.toUpperCase():
+  handleKeyDown(e) {
+    const visibilityKey = parseKey(this.props.toggleVisibilityKey);
+    const positionKey = parseKey(this.props.changePositionKey);
+
+    if (this.matchesKey(visibilityKey, e)) {
       e.preventDefault();
       this.props.dispatch(toggleVisibility());
-      break;
-    case this.props.changePositionKey.toUpperCase():
+    } else if (this.matchesKey(positionKey, e)) {
       e.preventDefault();
       this.props.dispatch(changePosition());
-      break;
-    default:
-      break;
     }
   }
 


### PR DESCRIPTION
I chose this library because it's way, way smaller than mice and we don't actually need a full keybinding library. We already have React to handle events. We just need to parse strings, and library seems to work well and it tiny.

Tested locally and seems to work. You can now specify keys such as `ctrl-shift-H`.
