### PR TITLE
Using webpack to build as a single file under /dist/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .DS_Store
 lib
 coverage
+dist

--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "description": "A resizable and movable dock for Redux DevTools monitors",
   "main": "lib/index.js",
   "scripts": {
+    "build:lib": "babel src --out-dir lib",
+    "build:umd": "webpack src/index.js dist/redux-devtools-dock-monitor.js --config webpack.config.development.js",
+    "build:umd:min": "webpack src/index.js dist/redux-devtools-dock-monitor.min.js --config webpack.config.production.js",
+    "build": "npm run build:lib && npm run build:umd && npm run build:umd:min",
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib",
     "lint": "eslint src test",
     "test": "NODE_ENV=test mocha --compilers js:babel/register --recursive",
     "test:watch": "NODE_ENV=test mocha --compilers js:babel/register --recursive --watch",

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var webpack = require('webpack');
+
+var reactExternal = {
+  root: 'React',
+  commonjs2: 'react',
+  commonjs: 'react',
+  amd: 'react'
+};
+
+var reduxExternal = {
+  root: 'Redux',
+  commonjs2: 'redux',
+  commonjs: 'redux',
+  amd: 'redux'
+};
+
+var reactReduxExternal = {
+  root: 'ReactRedux',
+  commonjs2: 'react-redux',
+  commonjs: 'react-redux',
+  amd: 'react-redux'
+};
+
+var reduxDevToolsExternal = {
+  root: 'ReduxDevTools',
+  commonjs2: 'redux-devtools',
+  commonjs: 'redux-devtools',
+  amd: 'redux-devtools'
+};
+
+module.exports = {
+  externals: {
+    'react': reactExternal,
+    'redux': reduxExternal,
+    'react-redux': reactReduxExternal,
+    'redux-devtools': reduxDevToolsExternal
+  },
+  module: {
+    loaders: [
+      { test: /\.js$/, loaders: ['babel-loader'], exclude: /node_modules/ }
+    ]
+  },
+  output: {
+    library: 'ReduxDevToolsDockMonitor',
+    libraryTarget: 'umd'
+  },
+  resolve: {
+    extensions: ['', '.js']
+  }
+};

--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var webpack = require('webpack');
+var baseConfig = require('./webpack.config.base');
+
+var config = Object.create(baseConfig);
+config.plugins = [
+  new webpack.optimize.OccurenceOrderPlugin(),
+  new webpack.DefinePlugin({
+    'process.env.NODE_ENV': JSON.stringify('development')
+  })
+];
+
+module.exports = config;

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var webpack = require('webpack');
+var baseConfig = require('./webpack.config.base');
+
+var config = Object.create(baseConfig);
+config.plugins = [
+  new webpack.optimize.OccurenceOrderPlugin(),
+  new webpack.DefinePlugin({
+    'process.env.NODE_ENV': JSON.stringify('production')
+  }),
+  new webpack.optimize.UglifyJsPlugin({
+    compressor: {
+      screw_ie8: true,
+      warnings: false
+    }
+  })
+];
+
+module.exports = config;


### PR DESCRIPTION
In addition to Babel build at `/lib/`, I would also prefer a webpack build as a single file at `/dist/` for easier consumption. Under "umd" module loading mechanism, it will appears as `global.ReduxDevToolsDockMonitor`.

For example, the next-gen syntax would looks like:

In `devtools.js`

``` js
var devTools = window.ReduxDevTools.createDevTools(
  <window.ReduxDevToolsDockMonitor toggleVisibilityKey='H'
                                   changePositionKey='Q'>
    <window.ReduxDevToolsLogMonitor />
  </window.ReduxDevToolsDockMonitor>
);
```

In `store.js`

``` js
var finalCreateStore = Redux.compose(
    devTools.instrument(),
    window.ReduxDevTools.persistState(window.location.href.match(/[?&]debug_session=([^&]+)\b/))
);
```
