### PR TITLE
Update to Babel 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "stage": 0,
-  "loose": "all"
+  "plugins": ["transform-react-jsx"],
+  "presets": ["es2015", "stage-0"]
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "clean": "rimraf lib",
     "build": "babel src --out-dir lib",
     "lint": "eslint src test",
-    "test": "NODE_ENV=test mocha --compilers js:babel/register --recursive",
-    "test:watch": "NODE_ENV=test mocha --compilers js:babel/register --recursive --watch",
+    "test": "NODE_ENV=test mocha --compilers js:babel-core/register --recursive",
+    "test:watch": "NODE_ENV=test mocha --compilers js:babel-core/register --recursive --watch",
     "prepublish": "npm run lint && npm run test && npm run clean && npm run build"
   },
   "repository": {
@@ -31,10 +31,13 @@
   },
   "homepage": "https://github.com/gaearon/redux-devtools-dock-monitor",
   "devDependencies": {
-    "babel": "^5.5.8",
-    "babel-core": "^5.6.18",
-    "babel-eslint": "^3.1.15",
-    "babel-loader": "^5.1.4",
+    "babel-cli": "^6.1.2",
+    "babel-core": "^6.1.2",
+    "babel-eslint": "^4.1.4",
+    "babel-loader": "^6.0.1",
+    "babel-plugin-transform-react-jsx": "^6.0.18",
+    "babel-preset-es2015": "^6.1.2",
+    "babel-preset-stage-0": "^6.1.2",
     "eslint": "^0.23",
     "eslint-config-airbnb": "0.0.6",
     "eslint-plugin-react": "^2.3.0",
@@ -48,7 +51,7 @@
     "redux-devtools": "^3.0.0-beta-3"
   },
   "dependencies": {
-    "babel-runtime": "^5.8.25",
+    "babel-runtime": "^6.0.14",
     "parse-key": "^0.2.1",
     "react-dock": "^0.2.1",
     "react-pure-render": "^1.0.2"

--- a/src/DockMonitor.js
+++ b/src/DockMonitor.js
@@ -5,7 +5,7 @@ import { toggleVisibility, changePosition, changeSize } from './actions';
 import reducer from './reducers';
 import parseKey from 'parse-key';
 
-export default class DockMonitor extends Component {
+class DockMonitor extends Component {
   static reducer = reducer;
 
   static propTypes = {
@@ -94,3 +94,5 @@ export default class DockMonitor extends Component {
     );
   }
 }
+
+export default DockMonitor;

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,22 +1,25 @@
 import { CHANGE_POSITION, CHANGE_SIZE, TOGGLE_VISIBILITY } from './actions';
 import { POSITIONS } from './constants';
 
-function position(state = props.defaultPosition, action, props) {
+function position(state, action, props) {
+  const s = state || props.defaultPosition;
   return (action.type === CHANGE_POSITION) ?
-    POSITIONS[(POSITIONS.indexOf(state) + 1) % POSITIONS.length] :
-    state;
+    POSITIONS[(POSITIONS.indexOf(s) + 1) % POSITIONS.length] :
+    s;
 }
 
-function size(state = props.defaultSize, action, props) {
+function size(state, action, props) {
+  const s = state || props.defaultSize;
   return (action.type === CHANGE_SIZE) ?
     action.size :
-    state;
+    s;
 }
 
-function isVisible(state = props.defaultIsVisible, action, props) {
+function isVisible(state, action, props) {
+  const s = state || props.defaultIsVisible;
   return (action.type === TOGGLE_VISIBILITY) ?
     !state :
-    state;
+    s;
 }
 
 function childMonitorState(state, action, props) {


### PR DESCRIPTION
I have split out `export default` onto a new line [because of this babel bug with static](https://phabricator.babeljs.io/T2779).
