### PR TITLE
fix: add babel-plugin-add-module-exports for default export

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["es2015-loose", "stage-0", "react"]
+  "presets": ["es2015-loose", "stage-0", "react"],
+  "plugins": [
+    "add-module-exports"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-core": "^6.1.20",
     "babel-eslint": "^5.0.0-beta4",
     "babel-loader": "^6.2.0",
+    "babel-plugin-add-module-exports": "^0.1.1",
     "babel-preset-es2015-loose": "^6.1.3",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",


### PR DESCRIPTION
[upgrading to Babel 6](https://github.com/gaearon/redux-devtools-dock-monitor/commit/766cdad4fc635098c1ae047e5226bc757be633db) silently broke everyone using `redux-devtools-dock-monitor` with CommonJS `require` and `module.exports` due to [Kill CommonJS default export behaviour - babel/babel#2212](https://phabricator.babeljs.io/T2212). this fixes that unintended breaking change.

repeat of https://github.com/gaearon/redux-thunk/pull/41
