### PR TITLE
Add defaultIsVisible to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Name                  | Description
 `fluid`               | When `true`, the dock size is a fraction of the window size, fixed otherwise. Optional. By default set to `true`.
 `defaultSize`         | Size of the dock. When `fluid` is `true`, a float (`0.5` means half the window size). When `fluid` is `false`, a width in pixels. Optional. By default set to `0.3` (3/10th of the window size).
 `defaultPosition`     | Where the dock appears on the screen. Valid values: `'left'`, `'top'`, `'right'`, `'bottom'`. Optional. By default set to `'right'`.
+`defaultIsVisible`    | Defines whether dock should be open by default. A value of `true` means that it's open when the page/app loads.
 
 The current size and the position are persisted between sessions with `persistState()` enhancer from Redux DevTools.
 


### PR DESCRIPTION
I was at a loss on how to make the dock hidden by default, until I found out about this undocumented property. This PR adds some documentation to the README.
