### PR TITLE
Support multiple monitors

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -12,3 +12,8 @@ export const CHANGE_SIZE = '@@redux-devtools-log-monitor/CHANGE_SIZE';
 export function changeSize(size) {
   return { type: CHANGE_SIZE, size: size };
 }
+
+export const CHANGE_MONITOR = '@@redux-devtools-log-monitor/CHANGE_MONITOR';
+export function changeMonitor() {
+  return { type: CHANGE_MONITOR };
+}

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,5 +1,11 @@
-import { CHANGE_POSITION, CHANGE_SIZE, TOGGLE_VISIBILITY } from './actions';
+import {
+  CHANGE_MONITOR,
+  CHANGE_POSITION,
+  CHANGE_SIZE,
+  TOGGLE_VISIBILITY
+} from './actions';
 import { POSITIONS } from './constants';
+import { Children } from 'react';
 
 function position(props, state = props.defaultPosition, action) {
   return (action.type === CHANGE_POSITION) ?
@@ -19,16 +25,47 @@ function isVisible(props, state = props.defaultIsVisible, action) {
     state;
 }
 
-function childMonitorState(props, state, action) {
-  const child = props.children;
-  return child.type.update(child.props, state, action);
+function childMonitorStates(props, state = [], action) {
+  return Children.map(props.children, (child, index) =>
+    child.type.update(child.props, state[index], action)
+  );
+}
+
+function childMonitorIndex(props, state = 0, action) {
+  switch (action.type) {
+  case CHANGE_MONITOR:
+    return (state + 1) % Children.count(props.children);
+  default:
+    return state;
+  }
 }
 
 export default function reducer(props, state = {}, action) {
+  if (!state.childMonitorStates) {
+    Children.forEach(props.children, (child, index) => {
+      if (typeof child.type.update !== 'function') {
+        console.error(
+          `Child of <DockMonitor> with the index ${index} ` +
+          `(${child.type.displayName || child.type.name || child.type }) ` +
+          'does not appear to be a valid Redux DevTools monitor.'
+        );
+      }
+    });
+  }
+
   return {
     position: position(props, state.position, action),
     isVisible: isVisible(props, state.isVisible, action),
     size: size(props, state.size, action),
-    childMonitorState: childMonitorState(props, state.childMonitorState, action)
+    childMonitorIndex: childMonitorIndex(
+      props,
+      state.childMonitorIndex,
+      action
+    ),
+    childMonitorStates: childMonitorStates(
+      props,
+      state.childMonitorStates,
+      action
+    )
   };
 }


### PR DESCRIPTION
This adds support for multiple monitors. There is no built-in UI but you can specify `changeMonitorKey='ctrl-m'` and it will loop through all the child monitors. Addresses #27.
