### PR TITLE
drop (unused) react-pure-render (fixes babel 6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   "dependencies": {
     "babel-runtime": "^6.2.0",
     "parse-key": "^0.2.1",
-    "react-dock": "^0.2.1",
-    "react-pure-render": "^1.0.2"
+    "react-dock": "^0.2.1"
   }
 }


### PR DESCRIPTION
- drop unused and unmaintained [react-pure-render](https://github.com/gaearon/react-pure-render) from package.json
- the .babelrc file in react-pure-render package was for babel 5, and breaks projects using babel 6

Very loosely related to:
- https://github.com/gaearon/react-pure-render/pull/13
- https://github.com/gaearon/react-pure-render/pull/20
- https://github.com/gaearon/react-pure-render/pull/23
- https://github.com/gaearon/react-pure-render/pull/26
- https://github.com/gaearon/react-pure-render/pull/28
