### PR TITLE
Use prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "babel-runtime": "^6.2.0",
     "parse-key": "^0.2.1",
+    "prop-types": "^15.5.8",
     "react-dock": "^0.2.1",
     "react-pure-render": "^1.0.2"
   }

--- a/src/DockMonitor.js
+++ b/src/DockMonitor.js
@@ -1,4 +1,5 @@
-import React, { cloneElement, Children, Component, PropTypes } from 'react';
+import React, { cloneElement, Children, Component } from 'react';
+import PropTypes from 'prop-types';
 import Dock from 'react-dock';
 import { POSITIONS } from './constants';
 import { toggleVisibility, changeMonitor, changePosition, changeSize } from './actions';


### PR DESCRIPTION
Current version gives the deprecation warning:

`Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.`